### PR TITLE
feat: remove argument from createHoneyPot

### DIFF
--- a/src/HoneyPotOEVShare.sol
+++ b/src/HoneyPotOEVShare.sol
@@ -8,11 +8,7 @@ import {IAggregatorV3Source} from "oev-contracts/interfaces/chainlink/IAggregato
 import {IMedian} from "oev-contracts/interfaces/chronicle/IMedian.sol";
 import {IPyth} from "oev-contracts/interfaces/pyth/IPyth.sol";
 
-contract HoneyPotOEVShare is
-    BaseController,
-    BoundedUnionSourceAdapter,
-    ChainlinkDestinationAdapter
-{
+contract HoneyPotOEVShare is BaseController, BoundedUnionSourceAdapter, ChainlinkDestinationAdapter {
     constructor(
         address chainlinkSource,
         address chronicleSource,

--- a/test/HoneyPot.sol
+++ b/test/HoneyPot.sol
@@ -10,12 +10,10 @@ import {HoneyPotOEVShare} from "../src/HoneyPotOEVShare.sol";
 import {HoneyPot} from "../src/HoneyPot.sol";
 
 contract HoneyPotTest is CommonTest {
-    IAggregatorV3Source chainlink =
-        IAggregatorV3Source(0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419);
+    IAggregatorV3Source chainlink = IAggregatorV3Source(0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419);
     IMedian chronicle = IMedian(0x64DE91F5A373Cd4c28de3600cB34C7C6cE410C85);
     IPyth pyth = IPyth(0x4305FB66699C3B2702D4d05CF36551390A4c69C6);
-    bytes32 pythPriceId =
-        0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace;
+    bytes32 pythPriceId = 0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace;
 
     HoneyPotOEVShare oevShare;
     HoneyPot honeyPot;
@@ -48,13 +46,8 @@ contract HoneyPotTest is CommonTest {
     }
 
     function mockChainlinkPriceChange() public {
-        (
-            uint80 roundId,
-            int256 answer,
-            uint256 startedAt,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        ) = chainlink.latestRoundData();
+        (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound) =
+            chainlink.latestRoundData();
         vm.mockCall(
             address(chainlink),
             abi.encodeWithSelector(chainlink.latestRoundData.selector),
@@ -72,8 +65,7 @@ contract HoneyPotTest is CommonTest {
         uint256 balanceBefore = address(this).balance;
 
         // Create HoneyPot for the caller
-        (, int256 latestAnswer, , , ) = oevShare.latestRoundData();
-        honeyPot.createHoneyPot{value: honeyPotBalance}(latestAnswer);
+        honeyPot.createHoneyPot{value: honeyPotBalance}();
 
         (, uint256 testhoneyPotBalance) = honeyPot.honeyPots(address(this));
         assertTrue(testhoneyPotBalance == honeyPotBalance);
@@ -81,19 +73,14 @@ contract HoneyPotTest is CommonTest {
 
         // Reset HoneyPot for the caller
         honeyPot.resetPot();
-        (, uint256 testhoneyPotBalanceReset) = honeyPot.honeyPots(
-            address(this)
-        );
+        (, uint256 testhoneyPotBalanceReset) = honeyPot.honeyPots(address(this));
         assertTrue(testhoneyPotBalanceReset == 0);
         assertTrue(address(this).balance == balanceBefore);
     }
 
     function testCrackHoneyPot() public {
         // Create HoneyPot for the caller
-        (, int256 latestAnswer, , , ) = oevShare.latestRoundData();
-        honeyPot.createHoneyPot{value: honeyPotBalance}(
-            latestAnswer
-        );
+        honeyPot.createHoneyPot{value: honeyPotBalance}();
         (, uint256 testhoneyPotBalance) = honeyPot.honeyPots(address(this));
         assertTrue(testhoneyPotBalance == honeyPotBalance);
 
@@ -114,13 +101,10 @@ contract HoneyPotTest is CommonTest {
 
         uint256 liquidatorBalanceAfter = liquidator.balance;
 
-        assertTrue(
-            liquidatorBalanceAfter == liquidatorBalanceBefore + honeyPotBalance
-        );
+        assertTrue(liquidatorBalanceAfter == liquidatorBalanceBefore + honeyPotBalance);
 
         // Create HoneyPot can be called again
-        (, int256 latestAnswerNew, , , ) = oevShare.latestRoundData();
-        honeyPot.createHoneyPot{value: honeyPotBalance}(latestAnswerNew);
+        honeyPot.createHoneyPot{value: honeyPotBalance}();
         (, uint256 testhoneyPotBalanceTwo) = honeyPot.honeyPots(address(this));
         assertTrue(testhoneyPotBalanceTwo == honeyPotBalance);
     }


### PR DESCRIPTION
I don't think this argument is needed. I think the normal flow would be to use the current price, and grabbing it automatically would make the flow much simpler on the FE.